### PR TITLE
Fixed Healthcheks

### DIFF
--- a/docker-vars.yaml
+++ b/docker-vars.yaml
@@ -11,7 +11,7 @@ tag: latest
 minerva_tag: v2
 
 # Ubuntu based image
-noctua_tag: v3
+noctua_tag: v4
 
 docker_hub_user: "{{ lookup('env', 'USER')|lower }}"
 apache_proxy_image: geneontology/apache-proxy:v4

--- a/docker/Dockerfile.noctua
+++ b/docker/Dockerfile.noctua
@@ -21,9 +21,11 @@ RUN cp config/startup.yaml.stack-dev startup.yaml \
 FROM ubuntu:18.04
 
 RUN apt-get update \
-    && apt-get install -y curl sudo
+    && apt-get install -y curl wget sudo
 RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-RUN apt-get install -y nodejs
+RUN apt-get install -y nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG uid=1100
 ARG gid=1100

--- a/production/PRODUCTION_README.md
+++ b/production/PRODUCTION_README.md
@@ -90,7 +90,7 @@ Check list:
 # Use the aws cli to make sure you have access to the terraform s3 backend bucket
 
 export AWS_SHARED_CREDENTIALS_FILE=/tmp/go-aws-credentials
-aws s3 ls s3://REPLACE_ME_WITH_TERRAFORM_BACKEND_BUCCKET # S3 bucket
+aws s3 ls s3://REPLACE_ME_WITH_TERRAFORM_BACKEND_BUCKET # S3 bucket
 go-deploy -init --working-directory aws -verbose
 ```
 
@@ -128,10 +128,10 @@ cat ./config-instance.yaml   # Verify contents and modify if needed.
 go-deploy --workspace production-YYYY-MM-DD --working-directory aws -verbose --conf config-instance.yaml
 
 # The previous command creates a terraform tfvars. These variables override the variables in `aws/main.tf`
-cat production-YYYY-MM-DD.json
+cat production-YYYY-MM-DD.tfvars.json
 
 # The previous command creates a ansible inventory file.
-cat production-YYYY-MM-DD--inventory.cfg
+cat production-YYYY-MM-DD-inventory.cfg
 
 # Useful terraform commands to check what you have just done
 terraform -chdir=aws workspace show   # current terraform workspace

--- a/production/PRODUCTION_README.md
+++ b/production/PRODUCTION_README.md
@@ -107,9 +107,7 @@ go-deploy --working-directory aws -list-workspaces -verbose
 
 ## Provision Instance on AWS
 
-We only need to provision the AWS instance once. This is because we
-only want one instance to manage the wildcard certificates. Use the
-terraform commands shown above to figure out the name of an existing
+Use the terraform commands shown above to figure out the name of an existing
 workspace. If such workspace exists, then you can skip the
 provisionning of the aws instance. Or you can destroy the aws instance
 and re-provision if that is the intent.

--- a/production/config-stack.yaml.sample
+++ b/production/config-stack.yaml.sample
@@ -14,6 +14,8 @@ stack:
      QS_ClientEventBlockCount: "350 300"
      QS_ClientEventBlockExcludeIP: "9.9.9.9"
 
+     minerva_java_opts: "-Xmx8G"
+
      USE_SSL: 1
      S3_SSL_CERTS_LOCATION: s3://REPLACE_ME_CERT_BUCKET/REPLACE_ME_DOMAIN.tar.gz
 

--- a/templates/qos.conf
+++ b/templates/qos.conf
@@ -10,7 +10,7 @@
   QS_ClientEntries {{ QS_ClientEntries }} 
 
   # IP addresses excluded from request limits (office IP address)
-  QS_ClientEventBlockExcludeIP {{ QS_ClientEventBlockExcludeIP }} 
+  QS_ClientEventBlockExcludeIP '{{ QS_ClientEventBlockExcludeIP }}'
 
   # Maximum number of connections allowed per IP, to server across all virtual hosts
   QS_SrvMaxConnPerIP {{ QS_SrvMaxConnPerIP }} 


### PR DESCRIPTION
- Testing revealed health checks no longer working since we updated noctua docker image from v2 to v3. 
Cause: "The wget command used in the health check was missing."
geneontology:noctua:v4 image brings in wget and has been pushed to dockerhub.

- Enhanced documentation.
