### PR TITLE
Tested with latest artifacts.

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -31,14 +31,40 @@ provider "aws" {
   profile = "default"
 }
 
+// optional will be created if value is not an menty string
+variable "dns_record_name" {
+  type = list(string)
+  description = "type A DNS records wich will be mapped to public ip"
+  default = []
+}
+
+variable "dns_zone_id" {
+  type = string
+  description = "zone id for dns record."
+  default = ""
+}
+
+variable "use_elastic_ip" {
+  type = bool
+  description = "whether to use an elastic ip or not"
+  default = true
+}
+
 module "base" {
-  source = "git::https://github.com/geneontology/devops-aws-go-instance.git?ref=V2.0"
+  source = "git::https://github.com/geneontology/devops-aws-go-instance.git?ref=V3.1"
   instance_type = var.instance_type
   ami = var.ami
   public_key_path = var.public_key_path
+  dns_record_name = var.dns_record_name
+  dns_zone_id = var.dns_zone_id
+  use_elastic_ip = var.use_elastic_ip
   tags = var.tags
   open_ports = var.open_ports
   disk_size = var.disk_size
+}
+
+output "dns_records" {
+  value = module.base.dns_records
 }
 
 output "public_ip" {

--- a/docker-vars.yaml
+++ b/docker-vars.yaml
@@ -14,4 +14,4 @@ minerva_tag: v3
 noctua_tag: v4
 
 docker_hub_user: "{{ lookup('env', 'USER')|lower }}"
-apache_proxy_image: geneontology/apache-proxy:v5
+apache_proxy_image: geneontology/apache-proxy:v6

--- a/production/config-instance.yaml.sample
+++ b/production/config-instance.yaml.sample
@@ -6,6 +6,12 @@ instance:
     tags:
        Name: REPLACE_ME 
     instance_type: t2.2xlarge
+    use_elastic_ip: True
+
+    # LIST OF DNS type A records to create.
+    dns_record_name: [ "REPLACE_ME_FQDN_FOR_NOCTUA", "REPLACE_ME_FQDN_FOR_BARISTA" ]
+    dns_zone_id: "REPLACE_ME_FOR_DNS_ZONE_ID"
+
     open_ports:
        - 80
        - 22

--- a/production/config-stack.yaml.sample
+++ b/production/config-stack.yaml.sample
@@ -5,7 +5,9 @@ ssh_keys:
 stack:
    vars:
      stage_dir: /home/ubuntu/stage_dir
-     PROD_MODE: 1 
+     PROD_MODE: 1
+
+     apache_proxy_image: geneontology/apache-proxy:v6
 
      S3_CRED_FILE: /tmp/go-aws-credentials
      S3_BUCKET: REPLACE_ME_APACHE_LOG__BUCKET
@@ -27,6 +29,7 @@ stack:
 
      # HTTP OR HTTPS
      noctua_host: REPLACE_ME # aes-test-noctua.geneontology.io
+     noctua_host_alias: REPLACE_ME
      noctua_lookup_url: REPLACE_ME # https://golr-aux.geneontology.io/solr/
      golr_neo_lookup_url: REPLACE_ME # https://aes-test-noctua.geneontology.io
 
@@ -41,5 +44,8 @@ stack:
 
      # HTTP OR HTTPS
      barista_lookup_host: REPLACE_ME # aes-test-barista.geneontology.io
+     barista_lookup_host_alias: REPLACE_ME
      barista_lookup_url: REPLACE_ME # https://aes-test-barista.geneontology.io
+
+     USE_CLOUDFLARE: 0
    scripts: [ stage.yaml, start_services.yaml]

--- a/templates/docker-compose-production.yaml
+++ b/templates/docker-compose-production.yaml
@@ -74,6 +74,7 @@ services:
       - S3_BUCKET={{ S3_BUCKET }}
       - USE_SSL={{ USE_SSL }}
       - S3_SSL_CERTS_LOCATION={{ S3_SSL_CERTS_LOCATION }}
+      - USE_CLOUDFLARE={{ USE_CLOUDFLARE }}
     init: true
     restart: unless-stopped
     depends_on:

--- a/vars.yaml
+++ b/vars.yaml
@@ -25,6 +25,10 @@ minerva_java_opts: "-Xmx4G"
 # Golr Index
 PROD_MODE: 0 
 #####
+#
+# 
+USE_CLOUDFLARE: 0
+
 ###############
 # Barista Local Authentication.
 ##############


### PR DESCRIPTION
Pointing to latest devops-aws-go-instance which supports the managment of dns records
Tested with latest python go-deploy tool. (devops-deployment-scripts) The tool now supports:
  -show
  -output
  -destroy